### PR TITLE
Fix custom clipboard executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+* Fixed custom clipboard executables
+
 ## 1.4.0 (2021/08/07)
 * Added OTP support
 * Updated go modules

--- a/kpmenulib/config.go
+++ b/kpmenulib/config.go
@@ -133,6 +133,11 @@ func (c *Configuration) LoadConfig() error {
 		if err := viper.UnmarshalKey("database", &c.Database); err != nil {
 			return NewErrorParseConfiguration("failed to parse config file (database): %v", err)
 		}
+
+		// Unmarshal executable
+		if err := viper.UnmarshalKey("executable", &c.Executable); err != nil {
+			return NewErrorParseConfiguration("failed to parse config file (executable): %v", err)
+		}
 	}
 	return nil
 }
@@ -159,6 +164,7 @@ func (c *Configuration) InitializeFlags() {
 	flag.StringVar(&c.Executable.CustomPromptFields, "customPromptFields", c.Executable.CustomPromptFields, "Custom executable for prompt fields")
 	flag.StringVar(&c.Executable.CustomClipboardCopy, "customClipboardCopy", c.Executable.CustomClipboardCopy, "Custom executable for clipboard copy")
 	flag.StringVar(&c.Executable.CustomClipboardPaste, "customClipboardPaste", c.Executable.CustomClipboardPaste, "Custom executable for clipboard paste")
+	flag.StringVar(&c.Executable.CustomClipboardClean, "customClipboardClean", c.Executable.CustomClipboardClean, "Custom executable for clipboard clean")
 
 	// Style
 	flag.StringVar(&c.Style.PasswordBackground, "passwordBackground", c.Style.PasswordBackground, "Color of dmenu background and text for password selection, used to hide password typing")

--- a/kpmenulib/kpmenulib.go
+++ b/kpmenulib/kpmenulib.go
@@ -167,12 +167,23 @@ func checkFlags(menu *Menu) error {
 		if err != nil {
 			return errors.New("wl-clipboard not found, exiting")
 		}
-	} else {
+	} else if menu.Configuration.General.ClipboardTool == ClipboardToolXsel {
 		// Check if xsel is installed
 		cmd := exec.Command("which", "xsel")
 		err := cmd.Run()
 		if err != nil {
 			return errors.New("xsel not found, exiting")
+		}
+	} else if menu.Configuration.General.ClipboardTool == ClipboardToolCustom {
+		// Check if CustomClipboardCopy, CustomClipboardPaste and CustomClipboardClean are set
+		if menu.Configuration.Executable.CustomClipboardCopy == "" {
+			return errors.New("when clipboardTool is set to custom, CustomClipboardCopy must be set")
+		}
+		if menu.Configuration.Executable.CustomClipboardPaste == "" {
+			return errors.New("when clipboardTool is set to custom, CustomClipboardPaste must be set")
+		}
+		if menu.Configuration.Executable.CustomClipboardClean == "" {
+			return errors.New("when clipboardTool is set to custom, CustomClipboardClean must be set")
 		}
 	}
 	return nil


### PR DESCRIPTION
The configuration for custom clipboard executables was not from the config file and custom clipboard tool was not considered in the `checkFlags()` function. This commit fixes these issues.